### PR TITLE
Fix tie-break points counting

### DIFF
--- a/src/main/python/contest/entry.py
+++ b/src/main/python/contest/entry.py
@@ -66,7 +66,7 @@ class Entry:
         count = 0
         for vote in self.votes[:voter+1]:
             try:
-                current_pts = int(vote)
+                current_pts = int(float(vote))
                 if current_pts == points:
                     count += 1
             except ValueError:


### PR DESCRIPTION
The variable 'vote' is a string that contains a floating point number,
not an integer, as the code previously assumed. Thus, all counts ended
up being zeros, which broke tie-breaking.