### PR TITLE
Remember previously selected folder during session

### DIFF
--- a/src/main/python/gui/window.py
+++ b/src/main/python/gui/window.py
@@ -1,5 +1,4 @@
-from os.path import expanduser
-from os.path import join
+from os.path import expanduser, join, dirname
 
 import qtawesome as qta
 import webcolors
@@ -24,6 +23,8 @@ class MainWindow(QMainWindow):
 
         self.contest = None
         self.thread = None
+
+        self._folder_path = expanduser("~")
 
         self._init_window()
         self._init_layout()
@@ -171,11 +172,11 @@ class MainWindow(QMainWindow):
         about_dialog.exec_()
 
     def _set_input_file(self):
-        home_directory = expanduser('~')
         dialog = QFileDialog()
         dialog.setFileMode(QFileDialog.ExistingFile)
-        path = dialog.getOpenFileName(self, 'Select Excel Spreadsheet', home_directory, 'Excel (*.xls, *.xlsx)')
+        path = dialog.getOpenFileName(self, 'Select Excel Spreadsheet', self._folder_path, 'Excel (*.xls, *.xlsx)')
         if path and len(path[0]) > 0:
+            self._folder_path = dirname(path[0])
             self.input_file_le.setText(path[0])
             self._load_contest()
 
@@ -211,11 +212,11 @@ class MainWindow(QMainWindow):
         alert.exec_()
 
     def _set_output_folder(self):
-        home_directory = expanduser('~')
         dialog = QFileDialog()
         dialog.setFileMode(QFileDialog.DirectoryOnly)
-        path = dialog.getExistingDirectory(self, 'Select Output Folder', home_directory, QFileDialog.ShowDirsOnly)
+        path = dialog.getExistingDirectory(self, 'Select Output Folder', self._folder_path, QFileDialog.ShowDirsOnly)
         if path and len(path) > 0:
+            self._folder_path = dirname(path)
             self.output_folder_le.setText(path)
 
     def _set_main_color(self):


### PR DESCRIPTION
This change attempts to slightly improve usability by remembering the
previously selected directory when choosing the input file or output
folder. The selected location is shared between input file location and
output folder, that is, the directory changes when either of them is
changed, The selection is not remembered between sessions, though.

Before this change, one had to navigate to the desired output location
starting from the home directory. If the user wants to store the output
pictures close to the input file, this navigation seems unnecessary. In
this case, remembering the previous location provides a quick way to get
to near the desired location, which was the motivation for this patch.

Another approach could be to remember input and output folders
separately. This might be beneficial if the user wants to store output
in completely different location than the input file.

Remembering the location also helps in case the user wants to reselect
a location for some reason, for example, due to a misclick.


To be honest, I am not sure if this is really needed but I thought it might be helpful in some cases.